### PR TITLE
Fixed some bug in EzFileCM and EzComponent classes

### DIFF
--- a/EzComponents.cs
+++ b/EzComponents.cs
@@ -876,9 +876,19 @@ namespace Microsoft.SqlServer.SSIS.EzAPI
             m_comp.MapInputColumn(m_meta.InputCollection[0].ID, InputCol(inputColName).ID, ExternalCol(externalColName).ID);
         }
 
-        public void UpmapColumn(string inputColName)
+        public void UnmapColumn(string inputColName)
         {
-            InputCol(inputColName).MappedColumnID = -1;
+            InputCol(inputColName).MappedColumnID = 0;
+            m_comp.MapInputColumn(m_meta.InputCollection[0].ID, InputCol(inputColName).ID, 0);
+        }
+
+        public void UnmapAllInputColumns()
+        {
+            foreach(IDTSInputColumn100 inputcol in m_meta.InputCollection[0].InputColumnCollection)
+            {
+                UnmapColumn(inputcol.Name);
+            }
+
         }
 
         public void MapOutputColumn(string outputColName, string externalColName)

--- a/EzConnections.cs
+++ b/EzConnections.cs
@@ -508,8 +508,8 @@ namespace Microsoft.SqlServer.SSIS.EzAPI
             {
                 if (Columns.Count > 0)
                     Columns[Columns.Count - 1].ColumnDelimiter = value;
-                else
-                    m_conn.Properties["RowDelimiter"].SetValue(m_conn, value);
+
+                m_conn.Properties["RowDelimiter"].SetValue(m_conn, value);
             }
         }
 


### PR DESCRIPTION
**EzComponent fixes and updates**

First i fixed the method name spelling from upmap to unmap, also the UnmapColumn function was not working well, Mapping the input column to 0 will remove the mapping with no problem (tested successfully).

Also i added a method UnmapAllInputColumns that can be used to remove all mapping made by default (columns with same name). It can be used if the user need to do all the mapping by himself.

**EzFileCM fixes**

I removed the moved the m_conn.Properties["RowDelimiter"].SetValue(m_conn, value); line outside the else clause since this property must be set regardless of the columns count. This property is shown inside of Flat File connection manager inside a combobox on the top of the columns preview. If we leave it inside the else clause then if the file contains columns the combobox value is empty.